### PR TITLE
Add standalone Korean todo list web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>투두 리스트</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <section class="todo">
+        <header class="todo__header">
+          <h1 class="todo__title">투두 리스트</h1>
+          <form class="todo__form" id="todo-form">
+            <input
+              type="text"
+              id="todo-input"
+              class="todo__input"
+              placeholder="할 일을 입력하세요"
+              aria-label="새 할 일"
+              required
+            />
+            <button type="submit" class="todo__button">추가</button>
+          </form>
+        </header>
+        <ul class="todo__list" id="todo-list" aria-live="polite"></ul>
+        <footer class="todo__footer">
+          <span id="todo-count">0개의 할 일이 남았습니다.</span>
+          <button type="button" id="clear-completed" class="todo__clear">
+            완료 항목 삭제
+          </button>
+        </footer>
+      </section>
+    </main>
+    <template id="todo-item-template">
+      <li class="todo-item">
+        <label class="todo-item__body">
+          <input type="checkbox" class="todo-item__checkbox" />
+          <span class="todo-item__text"></span>
+        </label>
+        <button type="button" class="todo-item__delete" aria-label="할 일 삭제">
+          ✕
+        </button>
+      </li>
+    </template>
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,135 @@
+const todoForm = document.querySelector('#todo-form');
+const todoInput = document.querySelector('#todo-input');
+const todoList = document.querySelector('#todo-list');
+const todoCount = document.querySelector('#todo-count');
+const clearCompletedButton = document.querySelector('#clear-completed');
+const todoTemplate = document.querySelector('#todo-item-template');
+
+const STORAGE_KEY = 'todo-items';
+
+function createId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+/** @type {{ id: string; text: string; completed: boolean }[]} */
+let todos = [];
+
+function loadTodos() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return;
+    const parsed = JSON.parse(stored);
+    if (Array.isArray(parsed)) {
+      todos = parsed.filter(
+        (item) =>
+          typeof item?.id === 'string' &&
+          typeof item?.text === 'string' &&
+          typeof item?.completed === 'boolean'
+      );
+    }
+  } catch (error) {
+    console.error('저장된 할 일을 불러오는 중 오류가 발생했습니다.', error);
+  }
+}
+
+function saveTodos() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(todos));
+}
+
+function updateCount() {
+  const remaining = todos.filter((todo) => !todo.completed).length;
+  todoCount.textContent =
+    remaining === 0
+      ? '모든 할 일을 완료했습니다!'
+      : `${remaining}개의 할 일이 남았습니다.`;
+}
+
+function createTodoElement(todo) {
+  const fragment = todoTemplate.content.cloneNode(true);
+  const item = fragment.querySelector('.todo-item');
+  const checkbox = fragment.querySelector('.todo-item__checkbox');
+  const text = fragment.querySelector('.todo-item__text');
+  const deleteButton = fragment.querySelector('.todo-item__delete');
+
+  text.textContent = todo.text;
+  checkbox.checked = todo.completed;
+
+  if (todo.completed) {
+    item.classList.add('todo-item--completed');
+  }
+
+  checkbox.addEventListener('change', () => {
+    todo.completed = checkbox.checked;
+    if (todo.completed) {
+      item.classList.add('todo-item--completed');
+    } else {
+      item.classList.remove('todo-item--completed');
+    }
+    saveTodos();
+    updateCount();
+  });
+
+  deleteButton.addEventListener('click', () => {
+    todos = todos.filter((current) => current.id !== todo.id);
+    item.remove();
+    saveTodos();
+    updateCount();
+    todoInput.focus();
+  });
+
+  return item;
+}
+
+function renderTodos() {
+  todoList.innerHTML = '';
+  const fragment = document.createDocumentFragment();
+  todos.forEach((todo) => {
+    fragment.appendChild(createTodoElement(todo));
+  });
+  todoList.appendChild(fragment);
+  updateCount();
+}
+
+function addTodo(text) {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return;
+  }
+
+  const newTodo = {
+    id: createId(),
+    text: trimmed,
+    completed: false,
+  };
+
+  todos.unshift(newTodo);
+  saveTodos();
+  renderTodos();
+}
+
+function clearCompleted() {
+  const hasCompleted = todos.some((todo) => todo.completed);
+  if (!hasCompleted) {
+    return;
+  }
+  todos = todos.filter((todo) => !todo.completed);
+  saveTodos();
+  renderTodos();
+}
+
+todoForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  addTodo(todoInput.value);
+  todoForm.reset();
+  todoInput.focus();
+});
+
+clearCompletedButton.addEventListener('click', clearCompleted);
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadTodos();
+  renderTodos();
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,216 @@
+:root {
+  font-size: 16px;
+  color-scheme: light dark;
+  --bg-color: #f5f5f7;
+  --card-color: #ffffffdd;
+  --text-color: #212529;
+  --accent-color: #4f46e5;
+  --accent-hover: #4338ca;
+  --border-color: #e0e0e0;
+  --shadow-color: rgba(79, 70, 229, 0.15);
+  --completed-color: #9ca3af;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #111827;
+    --card-color: #1f2937ee;
+    --text-color: #f9fafb;
+    --border-color: #374151;
+    --shadow-color: rgba(0, 0, 0, 0.35);
+    --completed-color: #6b7280;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Pretendard", "Noto Sans KR", -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  background: linear-gradient(180deg, var(--bg-color), #c7d2fe);
+  color: var(--text-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.app {
+  width: min(480px, 100%);
+}
+
+.todo {
+  background-color: var(--card-color);
+  border-radius: 1.5rem;
+  padding: 2.5rem 2rem;
+  box-shadow: 0 30px 50px -25px var(--shadow-color);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--border-color);
+}
+
+.todo__header {
+  margin-bottom: 1.75rem;
+}
+
+.todo__title {
+  margin: 0 0 1.5rem;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.todo__form {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.todo__input {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  background-color: transparent;
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.todo__input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.25);
+}
+
+.todo__button {
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 0.75rem;
+  background: var(--accent-color);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+}
+
+.todo__button:hover,
+.todo__button:focus {
+  background: var(--accent-hover);
+}
+
+.todo__button:active {
+  transform: translateY(1px);
+}
+
+.todo__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.todo-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.45);
+  border: 1px solid var(--border-color);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.todo-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px -30px var(--shadow-color);
+}
+
+.todo-item__body {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  flex: 1;
+}
+
+.todo-item__checkbox {
+  width: 1.2rem;
+  height: 1.2rem;
+  accent-color: var(--accent-color);
+}
+
+.todo-item__text {
+  font-size: 1rem;
+  word-break: break-word;
+  transition: color 0.2s ease, text-decoration 0.2s ease, opacity 0.2s ease;
+}
+
+.todo-item--completed .todo-item__text {
+  color: var(--completed-color);
+  text-decoration: line-through;
+  opacity: 0.7;
+}
+
+.todo-item__delete {
+  border: none;
+  background: transparent;
+  color: var(--completed-color);
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 0.5rem;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.todo-item__delete:hover,
+.todo-item__delete:focus {
+  color: var(--accent-color);
+  background: rgba(79, 70, 229, 0.1);
+}
+
+.todo__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 1.75rem;
+  font-size: 0.95rem;
+  color: var(--completed-color);
+}
+
+.todo__clear {
+  border: none;
+  background: none;
+  color: var(--accent-color);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  transition: background-color 0.2s ease;
+}
+
+.todo__clear:hover,
+.todo__clear:focus {
+  background: rgba(79, 70, 229, 0.1);
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1rem;
+  }
+
+  .todo {
+    padding: 2rem 1.5rem;
+  }
+
+  .todo__form {
+    flex-direction: column;
+  }
+
+  .todo__button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive Korean-language todo list layout with form, list, and controls
- implement interactive todo management with localStorage persistence and graceful id fallback
- style the interface with modern gradients, glassmorphism, and mobile-friendly adjustments

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dfdd8484708328aeabf207e0b37d78